### PR TITLE
RawCodeBlock: Safari/iOSでタイトル幅が狭くなる問題を修正

### DIFF
--- a/src/components/tutorial/RawCodeBlock.astro
+++ b/src/components/tutorial/RawCodeBlock.astro
@@ -13,7 +13,13 @@ const code = html.replace(/<p>|<\/p>/g, "")
 ---
 
 <div>
-  {title && <div data-rehype-pretty-code-title>{title}</div>}
+  {
+    title && (
+      <div class="flex" data-rehype-pretty-code-title>
+        {title}
+      </div>
+    )
+  }
   <pre class="_raw-code-block">
 <code>```{lang} {options}
 <Fragment set:text={code} />


### PR DESCRIPTION
![IMG_5255](https://github.com/tetracalibers/tomixyz-biography/assets/92695929/1d9b77b6-f78f-4fd9-adac-7cc2ecbb00d5)
