### PR TITLE
Prose: 引用部分のデザイン変更

### DIFF
--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -5,7 +5,7 @@ const { grid = true, fill = true } = Astro.props
 <article
   class:list={[
     { grid, fill },
-    "prose min-w-fit dark:prose-dark prose-a:underline-offset-4 prose-a:decoration-1 prose-a:decoration-dotted leading-loose tracking-wide"
+    "prose min-w-fit dark:prose-dark prose-a:underline-offset-4 prose-a:decoration-1 prose-a:decoration-dotted prose-blockquote:not-italic prose-blockquote:bg-blue-50/90 dark:prose-blockquote:bg-slate-500/50 prose-blockquote:rounded-tl-xl prose-blockquote:rounded-br-xl prose-blockquote:border prose-blockquote:py-4 prose-blockquote:px-6 leading-loose tracking-wide"
   ]}
 >
   <slot />
@@ -14,6 +14,16 @@ const { grid = true, fill = true } = Astro.props
 <style>
   .prose:empty {
     display: none;
+  }
+
+  .prose :global(blockquote > p) {
+    margin: 0;
+  }
+  .prose :global(blockquote > p::before) {
+    content: "";
+  }
+  .prose :global(blockquote > p::after) {
+    content: "";
   }
 
   .prose:has(> *:only-child:empty) {


### PR DESCRIPTION
## before

<img width="797" alt="スクリーンショット 2024-10-16 16 34 35" src="https://github.com/user-attachments/assets/463d6ca0-1df7-4c61-98d8-e18652b7748a">
<img width="797" alt="スクリーンショット 2024-10-16 16 35 17" src="https://github.com/user-attachments/assets/bd3ee87b-c867-4923-943e-9fd60d0a9084">

## after

<img width="899" alt="スクリーンショット 2024-10-16 16 38 12" src="https://github.com/user-attachments/assets/274883b1-65e2-4c1c-b39f-355b83bf4bd4">
<img width="899" alt="スクリーンショット 2024-10-16 16 38 02" src="https://github.com/user-attachments/assets/4445c02e-88e8-49b1-9c9b-4cb151dcf28c">

